### PR TITLE
Fixed problem with deserialization of lists , when no serialization was performed before

### DIFF
--- a/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/entity/json/JsonMarshaller.java
+++ b/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/entity/json/JsonMarshaller.java
@@ -25,7 +25,8 @@ public final class JsonMarshaller {
 	private JsonMarshaller() {
 		JsonFactory factory = new JsonFactory();
 		jsonMapper = new ObjectMapper(factory);
-		JsonUnknownPropertyHandler jsonUnknownPropertyHandler = new JsonUnknownPropertyHandler();
+        jsonMapper.enableDefaultTypingAsProperty(ObjectMapper.DefaultTyping.NON_FINAL, "@class");
+        JsonUnknownPropertyHandler jsonUnknownPropertyHandler = new JsonUnknownPropertyHandler();
 		jsonMapper.getDeserializationConfig().addHandler(jsonUnknownPropertyHandler);
 		jsonMapper.registerModule(new MrBeanModule());
 	}
@@ -33,6 +34,10 @@ public final class JsonMarshaller {
 	public static JsonMarshaller getInstance() {
 		return JsonMarshallerHolder.instance;
 	}
+
+    static JsonMarshaller createNew(){
+        return new JsonMarshaller();
+    }
 
 	public <T> T unmarshall(String jsonString, Class<?> objectType) {
 		Assert.notNull(jsonString);

--- a/spring-data-simpledb-impl/src/test/java/org/springframework/data/simpledb/core/entity/json/JsonMarshallerTest.java
+++ b/spring-data-simpledb-impl/src/test/java/org/springframework/data/simpledb/core/entity/json/JsonMarshallerTest.java
@@ -4,13 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 public class JsonMarshallerTest {
 
@@ -18,7 +18,7 @@ public class JsonMarshallerTest {
 
 	@Before
 	public void setUp() {
-		marshaller = JsonMarshaller.getInstance();
+		marshaller = JsonMarshaller.createNew();
 	}
 
 	@Test
@@ -95,6 +95,24 @@ public class JsonMarshallerTest {
 		assertEquals("Test Value", ret);
 
 	}
+
+    @Test
+    public void should_serialize_deserialize() throws Exception {
+        List<String> strings = new ArrayList<String>(asList("one", "two", "three"));
+
+        String result = marshaller.marshall(strings);
+        List<String> unmarshalled = marshaller.unmarshall(result, ArrayList.class);
+
+        assertThat(result, is("[\"java.util.ArrayList\",[\"one\",\"two\",\"three\"]]"));
+        assertThat(unmarshalled, is(strings));
+
+    }
+
+    @Test
+    public void should_deserialize_without_serialization() throws Exception {
+        ArrayList<String> result = marshaller.unmarshall("[\"java.util.ArrayList\",[\"one\",\"two\",\"three\"]]", ArrayList.class);
+        assertThat(result, is(new ArrayList<String>(asList("one", "two", "three"))));
+    }
 
 	private User createSampleUser() {
 		User newUser = new User();


### PR DESCRIPTION
Hi, i made a fix of the problem, discussed in subject. To test that it is a problem, rollback changes in JsonMarshaller and in test replace 
marshaller = JsonMarshaller.createNew();
with 
marshaller = JsonMarshaller.getInstance();
and run tests, you'll see that new added test should_deserialize_without_serialization will fail
