### PR TITLE
add count nextToken

### DIFF
--- a/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/SimpleDbTemplate.java
+++ b/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/SimpleDbTemplate.java
@@ -176,7 +176,7 @@ public class SimpleDbTemplate extends AbstractSimpleDbTemplate {
 		LOGGER.debug("Count items for query " + countQuery);
         validateSelectQuery(countQuery);
         final String escapedQuery = getEscapedQuery(countQuery, entityInformation);
-        
+        List<Item> selectResultList=new ArrayList<Item>();
 		String nextToken = null;
         Long totalCount=Long.valueOf(0);
         do{


### PR DESCRIPTION
If the count request takes more than five seconds, Amazon SimpleDB
returns the number of items that it could count and a next token to
return additional results. The client is responsible for accumulating
the partial counts.
