### PR TITLE
Add AWS region support on SimpleDB object

### DIFF
--- a/spring-data-simpledb-impl/pom.xml
+++ b/spring-data-simpledb-impl/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.1.5</version>
+			<version>1.8.10.2</version>
 		</dependency>
 
 

--- a/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/SimpleDb.java
+++ b/spring-data-simpledb-impl/src/main/java/org/springframework/data/simpledb/core/SimpleDb.java
@@ -1,5 +1,7 @@
 package org.springframework.data.simpledb.core;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.simpledb.core.domain.DomainManagementPolicy;
 
@@ -18,6 +20,8 @@ public class SimpleDb implements InitializingBean {
 
 	private String accessID;
 	private String secretKey;
+
+    private Regions region = Regions.US_EAST_1;
 
 	private DomainManagementPolicy domainManagementPolicy = DomainManagementPolicy.UPDATE;
 	private boolean consistentRead = false;
@@ -60,7 +64,20 @@ public class SimpleDb implements InitializingBean {
 		this.secretKey = secretKey;
 	}
 
-	/**
+    public Regions getRegion() {
+        return region;
+    }
+
+    /**
+     * Sets the AWS region to use. If not set US_EAST_1 is used by default.
+     *
+     * @param region
+     */
+    public void setRegion(Regions region) {
+        this.region = region;
+    }
+
+    /**
 	 * Set the domain management policy. This can be one of:
 	 * <ul>
 	 * <li><b>DROP_CREATE</b>: The domain will be dropped if it exists and created again
@@ -145,6 +162,7 @@ public class SimpleDb implements InitializingBean {
 		};
 
 		this.simpleDbClient = new AmazonSimpleDBClient(awsCredentials);
+        this.simpleDbClient.setRegion(Region.getRegion(region));
 
 		simpleDbDomain = new SimpleDbDomain(domainPrefix);
 	}


### PR DESCRIPTION
I have added support for aws regions on the SimpleDB object. To do this I had to update the version of the AWS client too
